### PR TITLE
upgrade beautifulsoup4 to 4.4.1 for python 3.5.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.3.2
+beautifulsoup4==4.4.1
 Pillow==2.6.1
 PyYAML==3.11
 cssselect==0.9.1


### PR DESCRIPTION
library is now compatible with python 3.5.0!

```
Python 3.5.0 (default, Oct 11 2015, 06:36:54)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.72)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import newspaper
>>> cnn_paper = newspaper.build('http://cnn.com')
>>> cnn_paper.size()
1251
```
